### PR TITLE
chore: add go-vulncheck

### DIFF
--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -1,0 +1,12 @@
+on: [push]
+
+jobs:
+  govulncheck_job:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+           go-version-input: 1.18
+           go-package: application/...


### PR DESCRIPTION
## 概要
#124 の対応

## 備考
govulncheckがgo 1.18からしか動かなかったため、go modとは違うバージョンを指定している